### PR TITLE
Fix detection of "Nothing to compile" situation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,11 @@ module.exports = function (grunt) {
           raw: 'sass_dir = "test/fixtures"\ncss_dir = "tmp3"'
         }
       },
+      compileNothing: {
+        options: {
+          sassDir: 'test/doesnt-exist',
+        }
+      },
       options: {
           outputStyle: 'compressed'
       }

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -18,6 +18,8 @@ module.exports = function (grunt) {
       cmd: args.shift(),
       args: args
     }, function (err, result, code) {
+      var success = code === 0;
+
       if (code === 127) {
         return grunt.warn(
           'You need to have Ruby and Compass installed ' +
@@ -25,9 +27,16 @@ module.exports = function (grunt) {
           'More info: https://github.com/gruntjs/grunt-contrib-compass'
         );
       }
-      // `compass compile` exits with 1 when it has nothing to compile
+
+      // `compass compile` exits with 1 and outputs "Nothing to compile"
+      // on stderr when it has nothing to compile.
       // https://github.com/chriseppstein/compass/issues/993
-      cb((code === 0 || !/Nothing to compile/g.test(result.stdout)) || result.stderr);
+      // Don't fail the task in this situation.
+      if (code === 1 && /Nothing to compile/g.test(result.stderr)) {
+        success = true;
+      }
+
+      cb(success);
     });
     child.stdout.pipe(process.stdout);
     child.stderr.pipe(process.stderr);


### PR DESCRIPTION
`compass compile` errors weren't failing the task.  I'm using Compass 0.12.2 and testing on both Mac and Linux.

The logic to detect the "Nothing to compile" situation seems wrong - at least for 0.12.2.  If `result.stderr` was truthy for any reason (which is the case for typical compile errors), the task would succeed.  Also, "Nothing to compile" appears in stderr, not stdout, on the versions/platforms I'm testing.

The build succeeds after my changes.

![Screen Shot 2013-03-28 at 10 57 16 AM](https://f.cloud.github.com/assets/1527302/314657/f768b674-97d0-11e2-9ce4-0b62bacff3ae.png)
