### PR TITLE
Expose raw options as Grunt options

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
 
     configContext(function (err, path) {
       if (err) {
-        grunt.fail.fatal(err);
+        grunt.fail.warn(err);
       }
 
       if (path) {

--- a/test/compass_test.js
+++ b/test/compass_test.js
@@ -79,5 +79,19 @@ exports.compass = {
       'should return the correct command.');
 
     test.done();
+  },
+  extractRawOptions: function (test) {
+    var options = {
+      unsupportedOption: 'irrellevant',
+      imagesPath: '/app/images',
+      httpImagesPath: '/path/"with/quotes'
+    };
+
+    var raw = compass.extractRawOptions(options);
+    // all but the unsupported options are removed.
+    test.equal(Object.keys(options).length, 1);
+    test.equal(raw.raw, 'images_path = "/app/images"\nhttp_images_path = "/path/\\"with/quotes"\n');
+    test.deepEqual(raw.options, ['imagesPath', 'httpImagesPath']);
+    test.done();
   }
 };


### PR DESCRIPTION
(See #30)

There is one issue with the current approach: Combining the `config` option with certain other options will raise a "The options `raw` and `config` are mutually exclusive" error. Any suggestions how this could be made more transparent to the user?
