### PR TITLE
Removed `preferred_syntax` as raw option

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -29,7 +29,6 @@ exports.init = function (grunt) {
       'http_generated_images_path',
       'javascripts_path',
       'http_javascripts_path',
-      'preferred_syntax',
       'fonts_path',
       'http_fonts_path',
       'http_fonts_dir'


### PR DESCRIPTION
There already is support for it and it doesn't accept strings as argument but
a symbol.
