### PR TITLE
Docs: Fix Bundler Exec link

### DIFF
--- a/docs/compass-options.md
+++ b/docs/compass-options.md
@@ -156,7 +156,7 @@ Turn off colorized output.
 
 ## bundleExec ```boolean```
 
-Run `compass compile` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html): `bundle exec compass compile`.
+Run `compass compile` with [bundle exec](http://gembundler.com/v1.3/man/bundle-exec.1.html): `bundle exec compass compile`.
 
 ## clean ```boolean```
 


### PR DESCRIPTION
The version string is now required in the docs URL
The current like just goes to the custom 404 page
