### PR TITLE
Readme: Fix Bundler Exec link

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Turn off colorized output.
 
 #### bundleExec ```boolean```
 
-Run `compass compile` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html): `bundle exec compass compile`.
+Run `compass compile` with [bundle exec](http://gembundler.com/v1.3/man/bundle-exec.1.html): `bundle exec compass compile`.
 
 #### clean ```boolean```
 


### PR DESCRIPTION
Same as #38 but for the README.
Sorry I didn't combine these but I didn't notice it till now.
