### PR TITLE
include timing info on compass compilation

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -104,6 +104,8 @@ exports.init = function (grunt) {
       args.push(options.basePath);
     }
 
+    args.push('--time');
+
     if (options.specify) {
       var files = grunt.file.expand({
         filter: function (filePath) {


### PR DESCRIPTION
This turns on compass compilation timing, so users aren't left wondering where their time is spent. Without this, it's hard to tell whether it's the fs watch or the actual compilation that is taking too long...
