### PR TITLE
Add support for disabling the asset cache buster

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,13 @@ Type: `String`
 
 The relative http path to the ad-hoc extensions folder on the web server. *Only Compass >=0.12.2*
 
+#### assetCacheBuster
+
+Type: `Boolean`  
+Default: `true`
+
+If set to `false`, this disables the default asset cache buster.
+
 #### require
 
 Type: `String|Array`

--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -48,6 +48,15 @@ exports.init = function (grunt) {
         delete options[option];
 
         return true;
+      } else if (underscoredOption === 'asset_cache_buster') {
+        // Special handling for asset_cache_buster as it doesn't take
+        // a string as argument, but either an inline-ruby block (which we don't
+        // support) or a `:none` symbol to disable it.
+        if (options[option] === false) {
+          raw += underscoredOption + ' :none';
+        }
+        delete options[option];
+        return true;
       }
     });
 

--- a/test/compass_test.js
+++ b/test/compass_test.js
@@ -115,6 +115,35 @@ exports.compass = {
     test.deepEqual(raw.options, ['imagesPath', 'httpImagesPath']);
     test.done();
   },
+  disableCacheBuster: function (test) {
+    var options = {
+      assetCacheBuster: false
+    };
+
+    var raw = compass.extractRawOptions(options);
+
+    test.expect(3);
+
+    test.equal(Object.keys(options).length, 0);
+    test.equal(raw.raw, 'asset_cache_buster :none');
+    test.deepEqual(raw.options, ['assetCacheBuster']);
+    test.done();
+  },
+  enableCacheBuster: function (test) {
+    var options = {
+      assetCacheBuster: true
+    };
+
+    var raw = compass.extractRawOptions(options);
+
+    test.expect(2);
+
+    test.equal(Object.keys(options).length, 0);
+    // There is no configuration generated for the case that we keep the cache
+    // buster enabled.
+    test.equal(raw.raw, '');
+    test.done();
+  },
   clean: function (test) {
     test.expect(1);
     test.equal(fs.existsSync('../.sass-cache'), false);


### PR DESCRIPTION
Fixes #70

I don't really like having to add a condition for this, but it's pretty much forced upon us by the inconsistent format compass expects.
