### PR TITLE
Add ability to pass options to child_process.spawn()

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -11,10 +11,11 @@
 module.exports = function (grunt) {
   var compass = require('./lib/compass').init(grunt);
 
-  function compile(args, cb) {
+  function compile(args, opts, cb) {
     var child = grunt.util.spawn({
       cmd: args.shift(),
-      args: args
+      args: args,
+      opts: opts
     }, function (err, result, code) {
       var success = code === 0;
 
@@ -57,6 +58,7 @@ module.exports = function (grunt) {
     var configContext = compass.buildConfigContext(options);
     // get the array of arguments for the compass command
     var args = compass.buildArgsArray(options);
+    var opts = compass.buildOptsObject(options);
 
     configContext(function (err, path) {
       if (err) {
@@ -67,7 +69,7 @@ module.exports = function (grunt) {
         args.push('--config', path);
       }
 
-      compile(args, function () {
+      compile(args, opts, function () {
         bannerCallback();
         cb();
       });

--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -117,6 +117,37 @@ exports.init = function (grunt) {
     };
   };
 
+  // build the array of options to pass to the spawn call
+  exports.buildOptsObject = function (options) {
+    var opts = {};
+
+    if (options.cwd) {
+      opts.cwd = options.cwd;
+    }
+
+    if (options.stdio) {
+      opts.stdio = options.stdio;
+    }
+
+    if (options.env) {
+      opts.env = options.env;
+    }
+
+    if (options.detached) {
+      opts.detached = options.detached;
+    }
+
+    if (options.uid) {
+      opts.uid = options.uid;
+    }
+
+    if (options.gid) {
+      opts.gid = options.gid;
+    }
+
+    return opts;
+  };
+
   // build the array of arguments to build the compass command
   exports.buildArgsArray = function (options) {
     var args = [options.clean ? 'clean' : 'compile'];
@@ -158,7 +189,8 @@ exports.init = function (grunt) {
       'clean',
       'bundleExec',
       'basePath',
-      'specify'
+      'specify',
+      'cwd'
     ]));
 
     // Compass doesn't have a long flag for this option:


### PR DESCRIPTION
The options cwd, stdio, env, detached, uid and gid are supported and are
passed to the spawn() call, so one can e.g. have a global Gruntfile to
compile compass-files in several subprojects by using cwd to change into
those subprojects.
