### PR TITLE
Fixing typo in extensions_dir option

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -35,7 +35,7 @@ exports.init = function (grunt) {
       'fonts_path',
       'http_fonts_path',
       'http_fonts_dir',
-      'extension_dir',
+      'extensions_dir',
       'extension_path'
     ];
 


### PR DESCRIPTION
According to [compass page](http://compass-style.org/help/tutorials/extensions/) `extension_dir` options should be `extensions_dir`. Current version throwing error, when `extensionsDir` is defined in `Gruntfile`. With `extensionDir` compass plugins are not working.
