### PR TITLE
Prevent compass from outputting color characters if the grunt no-color option is set.

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -178,6 +178,10 @@ exports.init = function (grunt) {
       });
     }
 
+    if (grunt.option('no-color')) {
+      args.push('--boring');
+    }
+
     return args;
   };
 


### PR DESCRIPTION
This is a pretty basic change. If grunt is run with the `no-color` option set, then no colour characters should be outputted. This change runs compass with the '--boring' flag if grunt no-color is set.
