### PR TITLE
Undefine property error on child if compass not installed.

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -34,8 +34,10 @@ module.exports = function (grunt) {
 
       cb();
     });
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
+    if (child) {
+      child.stdout.pipe(process.stdout);
+      child.stderr.pipe(process.stderr);
+    }
   }
 
   grunt.registerMultiTask('compass', 'Compile Sass to CSS using Compass', function () {


### PR DESCRIPTION
It happened on using concurrent task on yeoman
On win7 if you didn't have compass installed it failed with a undefined property error .
With this shows a proper message that reminds you to check if you have it installed .
