### PR TITLE
Allow disabling the `time` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,13 @@ Type: `Boolean`
 
 Quiet mode.
 
+### time
+
+Type: `Boolean`
+Default: `true`
+
+Shows time the task took.
+
 #### trace
 
 Type: `Boolean`

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
     var cb = this.async();
 
     // display compilation time
-    if (!options.clean) {
+    if (!options.clean && options.time !== false) {
       options.time = true;
     }
 


### PR DESCRIPTION
Current Compass 1.0.0.alpha.16 breaks with the `--time` option enabled: https://github.com/chriseppstein/compass/issues/1478

Even not taking the bug into account, it would be nice to be able to disable this option.
