### PR TITLE
Update compass.js

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -54,7 +54,7 @@ exports.init = function (grunt) {
         // a string as argument, but either an inline-ruby block (which we don't
         // support) or a `:none` symbol to disable it.
         if (options[option] === false) {
-          raw += underscoredOption + ' :none';
+          raw += underscoredOption + ' :none' + '\n';
         }
         delete options[option];
         return true;


### PR DESCRIPTION
I've spotted an issue (line n. 57) when you set the assetCacheBuster to false cause the corresponding Ruby option, asset_cache_buster, is created without a '\n' at the end.
