### PR TITLE
Option to disable the display of compilation time

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
 
     // display compilation time
     if (!options.clean) {
-      options.time = true;
+      options.time = options.hasOwnProperty('time') ? options.time : true;
     }
 
     // create a function to retroactively add a banner to the top of the


### PR DESCRIPTION
Allows user to disable the display of compilation time.
Helpful for using a pre-release version of compass (compass-sourcemaps) which breaks when passing `--time` parameter.
