### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The target directory where you keep your CSS stylesheets.
 
 Type: `String|Array`
 
-Lets you specify which files you want to compile. Useful if you don't want to compile the whole folder. Globbing supported. Ignores filenames starting with underscore. Files must be in the directory you specified in `sassDir`.
+Lets you specify which files you want to compile. Useful if you don't want to compile the whole folder. Globbing supported. Ignores filenames starting with underscore. 
 
 #### imagesDir
 


### PR DESCRIPTION
You must define 'specify' with their full path (including the sassDir), if you just specify the file names without a directory the task fails. The last sentence is confusing, so I suggest to remove it.
