### PR TITLE
Gracefully cleanup tmp config files when non-cli options are specified.

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -128,6 +128,7 @@ exports.init = function (grunt) {
 
     return function configContext(cb) {
       if (rawOptions.raw) {
+        tmp.setGracefulCleanup();
         tmp.file(function (err, path, fd) {
           if (err) {
             return cb(err);


### PR DESCRIPTION
Relies on https://github.com/raszi/node-tmp#graceful-cleanup
