### PR TITLE
Fix for issue #176, bundleExec on Win32

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -162,7 +162,11 @@ exports.init = function (grunt) {
     }
 
     if (options.bundleExec) {
-      args.unshift('bundle', 'exec');
+      if (process.platform === 'win32') {
+        args.unshift('bundle.bat', 'exec');
+      } else {
+        args.unshift('bundle', 'exec');
+      }
     }
 
     if (options.basePath) {


### PR DESCRIPTION
Fixes the 'bundle' binary not found error on Win32.
