### PR TITLE
Option to define the version of compass gem to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,12 @@ Type: `Boolean`
 
 Run `compass compile` with [bundle exec](http://gembundler.com/v1.3/man/bundle-exec.1.html): `bundle exec compass compile`.
 
+#### compassVersion
+
+Type: `String`
+
+Define which version of compass gem is used. This option sets `_version_` after compass executable, like `compass _1.0.1_ compile`.
+
 #### clean
 
 Type: `Boolean`
@@ -447,4 +453,4 @@ grunt.initConfig({
 
 Task submitted by [Sindre Sorhus](http://github.com/sindresorhus)
 
-*This file was generated on Thu Jan 15 2015 13:46:41.*
+*This file was generated on Thu Jan 15 2015 13:58:41.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-compass v1.0.1 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-compass.png?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-compass)
+# grunt-contrib-compass v1.0.1 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-compass.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-compass)
 
 > Compile Sass to CSS using Compass
 
@@ -447,4 +447,4 @@ grunt.initConfig({
 
 Task submitted by [Sindre Sorhus](http://github.com/sindresorhus)
 
-*This file was generated on Thu Dec 11 2014 12:41:29.*
+*This file was generated on Thu Jan 15 2015 13:46:41.*

--- a/docs/compass-options.md
+++ b/docs/compass-options.md
@@ -293,6 +293,12 @@ Type: `Boolean`
 
 Run `compass compile` with [bundle exec](http://gembundler.com/v1.3/man/bundle-exec.1.html): `bundle exec compass compile`.
 
+## compassVersion
+
+Type: `String`
+
+Define which version of compass gem is used. This option sets `_version_` after compass executable, like `compass _1.0.1_ compile`.
+
 ## clean
 
 Type: `Boolean`

--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -155,6 +155,10 @@ exports.init = function (grunt) {
 
     var basePath = options.basePath;
 
+    if (options.compassVersion) {
+      args.unshift('_' + options.compassVersion + '_');
+    }
+
     if (process.platform === 'win32') {
       args.unshift('compass.bat');
     } else {
@@ -194,7 +198,8 @@ exports.init = function (grunt) {
       'bundleExec',
       'basePath',
       'specify',
-      'watch'
+      'watch',
+      'compassVersion'
     ]));
 
     if (grunt.option('no-color')) {


### PR DESCRIPTION
If you have different version of compass installed and would like to switch between them you can use bundler or rvm. But in some cases it is not trivial. 
Because of this I would like to propose another, convinient way to set a version of compass to run. I've added an option, which sets `_version_` after compass executable, like `compass _1.0.1_ compile`. If this version of gem is installed it will be run, otherwise the task is aborted.