### PR TITLE
Fix #232: add --config path before `--` option/argument separator

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,6 +77,15 @@ module.exports = function (grunt) {
           banner: '/* <%= pkg.name %> banner */'
         }
       },
+      issue232: {
+        options: {
+          raw: 'Sass::Script::Number.precision = 10\n',
+          sassDir: 'test/fixtures',
+          cssDir: 'tmp6',
+          specify: 'test/fixtures/extension.css.scss',
+          banner: '/* <%= pkg.name %> banner */'
+        }
+      },
       clean: {
         options: {
           clean: true

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -66,7 +66,10 @@ module.exports = function (grunt) {
       }
 
       if (path) {
-        args.push('--config', path);
+        // Add --config path arguments, before -- option-argument separator , if one exists
+        // otherwise add to the end
+        var doubleDashIdx = args.indexOf('--');
+        args.splice(doubleDashIdx === -1 ? args.length : doubleDashIdx, 0, '--config', path);
       }
 
       binVersionCheck(args[0], '>=0.12.2', function (err) {

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -13,6 +13,7 @@ module.exports = function (grunt) {
   var compass = require('./lib/compass').init(grunt);
 
   function compile(args, cb) {
+    grunt.log.verbose.writeln('Running command: ' + args.join(' '));
     var child = grunt.util.spawn({
       cmd: args.shift(),
       args: args

--- a/test/compass_test.js
+++ b/test/compass_test.js
@@ -39,6 +39,13 @@ exports.compass = {
 
     test.done();
   },
+  issue232: function (test) {
+    test.expect(1);
+
+    test.ok(/\/\* grunt\-contrib\-compass banner \*\//.test(grunt.file.read('tmp6/extension.css')), 'should include the banner specified');
+
+    test.done();
+  },
   bundleExec: function (test) {
     var dataSet;
 


### PR DESCRIPTION
This should fix @mkilpatrick issue, he has `raw` in config.

Fixes #232 