### PR TITLE
feat(autoselect): Finds the first instance of compass and bundle in the ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "bin-version-check": "^2.0.0",
     "dargs": "^2.0.3",
     "onetime": "^1.0.0",
-    "tmp": "0.0.24"
+    "tmp": "0.0.24",
+    "which": "^1.0.9"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -6,6 +6,8 @@ exports.init = function (grunt) {
   var path = require('path');
   var async = require('async');
   var onetime = require('onetime');
+  var whichSync = require('which').sync;
+   
 
   var exports = {};
 
@@ -154,18 +156,12 @@ exports.init = function (grunt) {
       args = ['watch'];
     }
 
-    if (process.platform === 'win32') {
-      args.unshift('compass.bat');
-    } else {
-      args.unshift('compass');
-    }
+
+    //Autoselect extension   
+    args.unshift(whichSync('compass'));
 
     if (options.bundleExec) {
-      if (process.platform === 'win32') {
-        args.unshift('bundle.bat', 'exec');
-      } else {
-        args.unshift('bundle', 'exec');
-      }
+      args.unshift(whichSync('bundle'), 'exec');
     }
 
     // add converted options

--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -7,7 +7,7 @@ exports.init = function (grunt) {
   var async = require('async');
   var onetime = require('onetime');
   var whichSync = require('which').sync;
-   
+
 
   var exports = {};
 
@@ -157,11 +157,11 @@ exports.init = function (grunt) {
     }
 
 
-    //Autoselect extension   
-    args.unshift(whichSync('compass'));
+    //Autoselect extension
+    args.unshift(path.basename(whichSync('compass')));
 
     if (options.bundleExec) {
-      args.unshift(whichSync('bundle'), 'exec');
+      args.unshift(path.basename(whichSync('bundle')), 'exec');
     }
 
     // add converted options


### PR DESCRIPTION
Hi,
Please could you close this pull request [234](https://github.com/gruntjs/grunt-contrib-compass/pull/234).

Now, I use 'which' module to detect the extension of executable.
I'm working on Windows ( I'm ashamed ;)) and some tests doesn't work.
````javascript
   command: 'POSIXLY_CORRECT=1 grunt compass:compile'
    #unix like syntax, It isn't compatible with Windows (SET command: 'POSIXLY_CORRECT=1 grunt compass:compile')
````
But, my changes works on my platform.

I have decided to remove 
````javascript
if (process.platform === 'win32') {
````

and to trust 'which' module.
What do you think about this cleaning?

I can't test my changes on Mac OS or Linux. Have you any CI platform to validate them?
