### PR TITLE
Fix bundled compass triggering "not found: compass" since 1.1.0 update due to whichSync on compass before bundle

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -156,12 +156,12 @@ exports.init = function (grunt) {
       args = ['watch'];
     }
 
-
-    // Find the compass binary
-    args.unshift(path.basename(whichSync('compass')));
-
     if (options.bundleExec) {
+      args.unshift('compass');
       args.unshift(path.basename(whichSync('bundle')), 'exec');
+    } else {
+      // Find the compass binary
+      args.unshift(path.basename(whichSync('compass')));
     }
 
     // add converted options


### PR DESCRIPTION
Fixes issue raised in #248 