### PR TITLE
fix(bundleExec): pass only compass package name, not full path

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -156,12 +156,11 @@ exports.init = function (grunt) {
       args = ['watch'];
     }
 
-
-    // Find the compass binary
-    args.unshift(path.basename(whichSync('compass')));
-
     if (options.bundleExec) {
-      args.unshift(path.basename(whichSync('bundle')), 'exec');
+      args.unshift(path.basename(whichSync('bundle')), 'exec', 'compass');
+    } else {
+      // Find the compass binary
+      args.unshift(path.basename(whichSync('compass')));
     }
 
     // add converted options

--- a/test/compass_test.js
+++ b/test/compass_test.js
@@ -62,7 +62,7 @@ exports.compass = {
     };
 
     test.deepEqual(compass.buildArgsArray(dataSet),
-      [bundleBin, 'exec', compassBin, 'compile'],
+      [bundleBin, 'exec', 'compass', 'compile'],
       'should return the correct command.');
 
     test.done();


### PR DESCRIPTION
compass full path needs to be used only when no using bundleExec. when bundleExex is used command should be `~/.../bundle exec compass` and not `~/.../bundle exec ~/.../compass` as it is today.

Closes #248
Closes #249