### PR TITLE
Update bin version check dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "bin-version-check": "^2.0.0",
+    "bin-version-check": "^5.0.0",
     "dargs": "^2.0.3",
     "onetime": "^1.0.0",
     "tmp": "0.0.28",


### PR DESCRIPTION
A drilled down dependency `trim-newlines` is at version `1.0.0` right now and is causing a security risk for users of this package. This dependency update corrects this issue.